### PR TITLE
feat/3 친구 검색, 추가, 조회, 삭제 API 구현

### DIFF
--- a/src/main/java/growthook/org/bamgang/members/controller/MemberController.java
+++ b/src/main/java/growthook/org/bamgang/members/controller/MemberController.java
@@ -34,7 +34,7 @@ public class MemberController {
     @Value("${kakao-key}")
     private String apiKey;
 
-
+    // 멤버 정보 조회
     @GetMapping("/{id}")
     public GetMemberResponseDto getUserInfo(@PathVariable("id") int id){
         GetMemberResponseDto getMemberResponseDto = memberService.findById(id);
@@ -279,5 +279,13 @@ public class MemberController {
             return ResponseEntity.status(500).body("로그아웃 실패");
         }
     }
+
+    // 친구 검색
+    @GetMapping("/friend/{targetUserEmail}")
+    public GetMemberResponseDto searchFriends(@PathVariable("targetUserEmail") String targetUserEmail){
+        GetMemberResponseDto getMemberResponseDto = MemberService.findByEmail(targetUserEmail);
+        return getMemberResponseDto;
+    }
+
 }
 

--- a/src/main/java/growthook/org/bamgang/members/controller/MemberController.java
+++ b/src/main/java/growthook/org/bamgang/members/controller/MemberController.java
@@ -4,13 +4,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import growthook.org.bamgang.members.dto.request.FinishedDestinationRequest;
 import growthook.org.bamgang.members.dto.request.FinishedWalkRequest;
+import growthook.org.bamgang.members.dto.request.AddFriendRequest;
 import growthook.org.bamgang.members.dto.request.PickedWalkRequest;
 import growthook.org.bamgang.members.dto.response.*;
 import growthook.org.bamgang.members.dto.token.MemberToken;
 import growthook.org.bamgang.members.jwtUtil.JWTUtil;
 import growthook.org.bamgang.members.service.MemberService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.util.LinkedMultiValueMap;
@@ -281,10 +281,30 @@ public class MemberController {
     }
 
     // 친구 검색
-    @GetMapping("/friend/{targetUserEmail}")
+    @GetMapping("/friend/search/{targetUserEmail}")
     public GetMemberResponseDto searchFriends(@PathVariable("targetUserEmail") String targetUserEmail){
-        GetMemberResponseDto getMemberResponseDto = MemberService.findByEmail(targetUserEmail);
+        GetMemberResponseDto getMemberResponseDto = memberService.findByEmail(targetUserEmail);
         return getMemberResponseDto;
+    }
+
+    // 친구 추가
+    @PutMapping("/friend/{userId}")
+    public GetMemberResponseDto updateFriends(@PathVariable("userId") int userId, @RequestBody AddFriendRequest friendRequest){
+        GetMemberResponseDto getMemberResponseDto = memberService.addFriendById(userId, friendRequest);
+        return getMemberResponseDto;
+    }
+
+    // 친구 정보 가져오기
+    @GetMapping("/friend/{userId}")
+    public GetMemberResponseDto getFriendInfo(@PathVariable("userId") int userId) {
+        GetMemberResponseDto friendInfo = memberService.getFriendInfo(userId);
+        return friendInfo;
+    }
+
+    // 친구 관계 삭제
+    @DeleteMapping("/friend/{userId}")
+    public void deleteFriend(@PathVariable("userId") int userId) {
+        memberService.removeFriend(userId);
     }
 
 }

--- a/src/main/java/growthook/org/bamgang/members/dto/request/AddFriendRequest.java
+++ b/src/main/java/growthook/org/bamgang/members/dto/request/AddFriendRequest.java
@@ -1,0 +1,8 @@
+package growthook.org.bamgang.members.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class AddFriendRequest {
+    private Integer friendId;
+}

--- a/src/main/java/growthook/org/bamgang/members/dto/response/GetMemberResponseDto.java
+++ b/src/main/java/growthook/org/bamgang/members/dto/response/GetMemberResponseDto.java
@@ -17,4 +17,8 @@ public class GetMemberResponseDto {
     private Integer pickedCount;
 
     private String profile;
+
+    private Integer familyId;
+
+    private String email;
 }

--- a/src/main/java/growthook/org/bamgang/members/exception/MemberNotFoundException.java
+++ b/src/main/java/growthook/org/bamgang/members/exception/MemberNotFoundException.java
@@ -1,0 +1,7 @@
+package growthook.org.bamgang.members.exception;
+
+public class MemberNotFoundException extends RuntimeException {
+    public MemberNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/growthook/org/bamgang/members/repository/MemberRepository.java
+++ b/src/main/java/growthook/org/bamgang/members/repository/MemberRepository.java
@@ -11,4 +11,6 @@ public interface MemberRepository extends JpaRepository<Member, Integer> {
     Optional<Member> findByUserId(int userId);
 
     Member findByPassword(String password);
+
+    Optional<Member> findByEmail(String targetUserEmail);
 }

--- a/src/main/java/growthook/org/bamgang/members/service/MemberService.java
+++ b/src/main/java/growthook/org/bamgang/members/service/MemberService.java
@@ -25,7 +25,7 @@ import java.util.Optional;
 @Transactional(readOnly = true)
 public class MemberService {
 
-    private MemberRepository memberRepository;
+    private static MemberRepository memberRepository;
 
     private DataFinishedWalkRepository finishedWalkRepository;
 
@@ -50,6 +50,8 @@ public class MemberService {
         this.dataFinishedDestintationRepository = dataFinishedDestintationRepository;
         this.searchWordRepository = searchWordRepository;
     }
+
+
 
     // Member 추가
     @Transactional
@@ -95,6 +97,8 @@ public class MemberService {
                 .pickedCount(member.getPickedCount())
                 .walkedDay(member.getWalkedDay())
                 .profile(member.getProfile())
+                .familyId(member.getFamilyId())
+                .email(member.getEmail())
                 .build();
         return getMemberResponseDto;
     }
@@ -107,6 +111,22 @@ public class MemberService {
         } else {
             throw new IllegalArgumentException("ID가 " + id + "인 멤버가 존재하지 않습니다");
         }
+    }
+
+    // Email로 친구 찾기
+    public static GetMemberResponseDto findByEmail(String targetUserEmail) {
+        Member member = memberRepository.findByEmail(targetUserEmail).orElseThrow(()-> new RuntimeException());
+        GetMemberResponseDto getMemberResponseDto = GetMemberResponseDto.builder()
+                .nickName(member.getNickName())
+                .exp(member.getExp())
+                .finishedCount(member.getFinishedCount())
+                .pickedCount(member.getPickedCount())
+                .walkedDay(member.getWalkedDay())
+                .profile(member.getProfile())
+                .familyId(member.getFamilyId())
+                .email(member.getEmail())
+                .build();
+        return getMemberResponseDto;
     }
 
     // 완료한 산책로 조회


### PR DESCRIPTION
### #️⃣ 연관된 이슈
- resolve #3 

### 📝 작업 내용
- 친구 검색, 추가, 조회, 삭제 API 구현했습니다.
- 친구 검색: email로 친구 정보 조회
- ![image](https://github.com/user-attachments/assets/8058a9a3-1c62-439b-8acf-685c0146b08b)

- 친구 추가: 친구 id를 request body로 보내서 해당 친구 추가
- ![image](https://github.com/user-attachments/assets/d1bcf4a5-ff89-4fae-b1a5-8172e529abfb)

- 친구 조회: 내 ID에 등록되어 있는 친구 조회
- ![image](https://github.com/user-attachments/assets/d1f6f30c-e877-4769-8a96-c7410395b4a1)

- 친구 삭제: 내 ID보내서 familyId null로 바꿈
- ![image](https://github.com/user-attachments/assets/6977ea87-1325-4cec-90ca-b44dc9933713)


### 🙏 리뷰 요구사항
- PR 각각 쓸 시간이 없어서... 송구합니다
